### PR TITLE
Fix compiler warning pertaining to deprecated method

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -16,6 +16,7 @@
 #include "connection.h"
 #include "requestdialog.h"
 #include "websockets.h"
+#include <QRegularExpression>
 
 using json = nlohmann::json;
 
@@ -443,7 +444,7 @@ void MainWindow::setupSettingsModal() {
 
 void MainWindow::addressBook() {
     // Check to see if there is a target.
-    QRegExp re("Address[0-9]+", Qt::CaseInsensitive);
+    QRegularExpression re("Address[0-9]+", QRegularExpression::CaseInsensitiveOption);
     for (auto target: ui->sendToWidgets->findChildren<QLineEdit *>(re)) {
         if (target->hasFocus()) {
             AddressBook::open(this, target);


### PR DESCRIPTION
Previously when compiling, the following deprecation warning would be
encountered:

```
src/mainwindow.cpp:447:70: warning: ‘QList<T> QObject::findChildren(const QRegExp&, Qt::FindChildOptions) const [with T = QLineEdit*; Qt::FindChildOptions = QFlags<Qt::FindChildOption>]’ is deprecated: Use findChildren(const QRegularExpression &, ...) instead. [-Wdeprecated-declarations]
```

This commit updates this line to the non-deprecated QT5 version of this
method, which uses QRegularExpression rather than QRegExp, thus removing
the warning.