### PR TITLE
Pass -dead_strip and -dead_strip_dylibs

### DIFF
--- a/zecwallet-lite.pro
+++ b/zecwallet-lite.pro
@@ -29,6 +29,7 @@ INCLUDEPATH  += src/
 
 LIBS+= -Wl,-dead_strip
 LIBS+= -Wl,-dead_strip_dylibs
+LIBS+= -Wl,-bind_at_load
 
 RESOURCES     = application.qrc
 

--- a/zecwallet-lite.pro
+++ b/zecwallet-lite.pro
@@ -27,6 +27,9 @@ DEFINES += \
 INCLUDEPATH  += src/3rdparty/
 INCLUDEPATH  += src/
 
+LIBS+= -Wl,-dead_strip
+LIBS+= -Wl,-dead_strip_dylibs
+
 RESOURCES     = application.qrc
 
 MOC_DIR = bin


### PR DESCRIPTION
Porting https://github.com/ZcashFoundation/zecwallet/pull/215.

Before:
<img width="859" alt="Screen Shot 2020-01-12 at 17 43 02" src="https://user-images.githubusercontent.com/227442/72221544-a9cce280-3564-11ea-82c9-70f532d2cd5d.png">
After:
<img width="858" alt="Screen Shot 2020-01-12 at 17 53 25" src="https://user-images.githubusercontent.com/227442/72221549-adf90000-3564-11ea-93be-b21b9e90c9c5.png">

Before:
```
$ otool -L zecwallet-lite.app/Contents/MacOS/zecwallet-lite
/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59306.41.2)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1673.126.0)
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1894.10.126)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 212.2.3)
	/opt/local/libexec/qt5/lib/QtWebSockets.framework/Versions/5/QtWebSockets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
After:
```
$ otool -L zecwallet-lite.app/Contents/MacOS/zecwallet-lite
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59306.41.2)
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtWebSockets.framework/Versions/5/QtWebSockets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtNetwork.framework/Versions/5/QtNetwork (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```