### PR TITLE
add missing import for memo replies

### DIFF
--- a/app/components/Transactions.js
+++ b/app/components/Transactions.js
@@ -12,6 +12,7 @@ import cstyles from './Common.module.css';
 import { Transaction, Info } from './AppState';
 import ScrollPane from './ScrollPane';
 import Utils from '../utils/utils';
+import { ZcashURITarget } from '../utils/uris';
 import AddressBook from './Addressbook';
 import routes from '../constants/routes.json';
 import RPC from '../rpc';


### PR DESCRIPTION
Currently, clicking on the memo "Reply" button does not trigger modal due to a missing import statement.