### PR TITLE
Add missing import to address book

### DIFF
--- a/app/components/Addressbook.js
+++ b/app/components/Addressbook.js
@@ -13,6 +13,7 @@ import cstyles from './Common.module.css';
 import { AddressBookEntry } from './AppState';
 import ScrollPane from './ScrollPane';
 import Utils from '../utils/utils';
+import { ZcashURITarget } from '../utils/uris';
 import routes from '../constants/routes.json';
 
 // Internal because we're using withRouter just below


### PR DESCRIPTION
Currently, clicking on the "Send To" button in the address book does not display the Send screen due to a missing import statement.

 